### PR TITLE
Issue #34

### DIFF
--- a/qanta/guesser/util/load_embeddings.py
+++ b/qanta/guesser/util/load_embeddings.py
@@ -15,7 +15,6 @@ def create():
 
     for line in vec_file:
         split = line.split()
-        # Getting 
         word = " ".join(split[:-300])
         if word not in wmap:
             continue

--- a/qanta/guesser/util/load_embeddings.py
+++ b/qanta/guesser/util/load_embeddings.py
@@ -15,11 +15,12 @@ def create():
 
     for line in vec_file:
         split = line.split()
-        word = split[0]
+        # Getting 
+        word = " ".join(split[:-300])
         if word not in wmap:
             continue
         x = wmap[word]
-        all_vocab[word] = array(split[1:])
+        all_vocab[word] = array(split[-300:])
         all_vocab[word] = all_vocab[word].astype(float)
 
     log.info("wmap: {0} all_vocab: {1}".format(len(wmap), len(all_vocab)))


### PR DESCRIPTION
**Details:**
Some words in the word_embeddings are multi-tokens (examples below). This is causing `all_vocab[word] = array(split[1:])` to include part of the word as embedding resulting in error at line 23 `all_vocab[word] = all_vocab[word].astype(float)`.  Details of error in [Issue #34](https://github.com/Pinafore/qb/issues/34)

**Suggested solution:**
Given that the embeddings dimension is 300, the updated code assumes all but the last 300 splits to be part of the word tokens.  Also the last 300 to be the actual embeddings.  This would break however with WE of sizes different than 300.  A better solution is to dynamically assign the dimension rather than hard coding it.

**Alternative solution:**
Ignore these cases by checking if len(split) is > 301

Examples from data/external/deep/glove.840B.300d.txt :
```
mail：name@domain.com 0.46949 -0.5331 0.41987 0.21681 -0.4169 0.35045 0.10753 .......
is name@domain.com -0.1197 0.10706 -0.10519 -0.12412 0.4096 -0.0287 0.34704 0.3549 ...........
news:#name@domain.com 0.97894 -0.57796 0.22701 -0.81661 -0.11701 0.1271 ...........
```