### PR TITLE
Fix config mismatch

### DIFF
--- a/qanta/guesser/abstract.py
+++ b/qanta/guesser/abstract.py
@@ -489,7 +489,7 @@ class AbstractGuesser(metaclass=ABCMeta):
 
         guesser_lookup = {}
         for name, g in conf["guessers"].items():
-            g_qualified_name = g["class"]
+            g_qualified_name = name
             parts = g_qualified_name.split(".")
             g_module = ".".join(parts[:-1])
             g_classname = parts[-1]


### PR DESCRIPTION
The default config does not have any "class" key in the guessers as written, so "name" should be used instead.